### PR TITLE
Read every docx file only once

### DIFF
--- a/src/kohlrahbi/__init__.py
+++ b/src/kohlrahbi/__init__.py
@@ -124,7 +124,7 @@ def load_all_known_pruefis_from_file(
     is_flag=True,
     help="Confirm all prompts automatically.",
 )
-# pylint: disable=too-many-branches
+# pylint: disable=too-many-branches, too-many-statements
 def main(pruefis: list[str], input_path: Path, output_path: Path, file_type: list[str], assume_yes: bool):
     """
     A program to get a machine readable version of the AHBs docx files published by edi@energy.


### PR DESCRIPTION
The CPU profiler says that reading the docx / XML documents takes significant amount of time. This PR prevents the CLI tool to re-read / re-instiante `docx.Document`s that have already been read before.
This might use more memory 🙄but should reduce the time needed to read all documents.