### PR TITLE
Don't try to find deprecated 11... Prüfis in >= 2023-10-01 Files

### DIFF
--- a/src/kohlrahbi/ahbfilefinder.py
+++ b/src/kohlrahbi/ahbfilefinder.py
@@ -89,5 +89,16 @@ class AhbFileFinder:
 
         self.filter_for_latest_ahb_docx_files()
         self.filter_docx_files_for_edifact_format(edifact_format=edifact_format)
-
+        if (
+            edifact_format == EdifactFormat.UTILMD
+            and searched_pruefi.startswith("11")
+            and all(["202310" in path.name for path in self.paths_to_docx_files])
+        ):
+            logger.info(
+                # pylint:disable:line-too-long
+                "You searched for a UTILMD prüfi %s starting with the soon deprecated prefix '11' but all relevant files %s are valid from 2023-10 onwards. They won't contain any match.",
+                searched_pruefi,
+                ", ".join([path.name for path in self.paths_to_docx_files]),
+            )
+            return []
         return self.paths_to_docx_files

--- a/src/kohlrahbi/ahbfilefinder.py
+++ b/src/kohlrahbi/ahbfilefinder.py
@@ -95,7 +95,7 @@ class AhbFileFinder:
             and all(["202310" in path.name for path in self.paths_to_docx_files])
         ):
             logger.info(
-                # pylint:disable:line-too-long
+                # pylint:disable=line-too-long
                 "You searched for a UTILMD prüfi %s starting with the soon deprecated prefix '11' but all relevant files %s are valid from 2023-10 onwards. They won't contain any match.",
                 searched_pruefi,
                 ", ".join([path.name for path in self.paths_to_docx_files]),

--- a/src/kohlrahbi/ahbfilefinder.py
+++ b/src/kohlrahbi/ahbfilefinder.py
@@ -92,7 +92,7 @@ class AhbFileFinder:
         if (
             edifact_format == EdifactFormat.UTILMD
             and searched_pruefi.startswith("11")
-            and all(["202310" in path.name for path in self.paths_to_docx_files])
+            and all("202310" in path.name for path in self.paths_to_docx_files)
         ):
             logger.info(
                 # pylint:disable=line-too-long


### PR DESCRIPTION
this should speed up the "scrape everything" approach. alternatively we could remove the 11... prüfis from the "all_known_pruefis" if we know that we're in FV2310