### PR TITLE
🐛: Re-instantiate `ahb_file_finder` for every pruefi

### DIFF
--- a/src/kohlrahbi/__init__.py
+++ b/src/kohlrahbi/__init__.py
@@ -156,13 +156,12 @@ def main(pruefis: list[str], input_path: Path, output_path: Path, file_type: lis
     if len(valid_pruefis) != len(pruefis):
         click.secho("☝️ Not all given pruefidentifikatoren are valid.", fg="yellow")
         click.secho(f"I will continue with the following valid pruefis: {valid_pruefis}.", fg="yellow")
-    ahb_file_finder = AhbFileFinder.from_input_path(input_path=input_path)
     path_to_document_mapping: dict[Path, docx.Document] = {}
 
     for pruefi in valid_pruefis:
         try:
             logger.info("start looking for pruefi '%s'", pruefi)
-
+            ahb_file_finder = AhbFileFinder.from_input_path(input_path=input_path)
             ahb_file_paths: list[Path] = ahb_file_finder.get_docx_files_which_may_contain_searched_pruefi(
                 searched_pruefi=pruefi
             )

--- a/src/kohlrahbi/ahbfilefinder.py
+++ b/src/kohlrahbi/ahbfilefinder.py
@@ -27,6 +27,8 @@ class AhbFileFinder:
         ahb_file_paths: list[Path] = [
             path for path in input_path.iterdir() if path.is_file() if path.suffix == ".docx" if "AHB" in path.name
         ]
+        if not any(ahb_file_paths):  # this is suspicious at least
+            logger.warning("The directory '%s' does not contain any AHB docx files.", input_path.absolute())
         return cls(paths_to_docx_files=ahb_file_paths)
 
     @staticmethod
@@ -46,7 +48,7 @@ class AhbFileFinder:
         result: list[Path] = []
 
         groups: dict[str, list[Path]] = {}  # the key is the first part of the file name, the values are matching files
-
+        logger.debug("The list self.paths_to_docx_files contains %i entries", len(self.paths_to_docx_files))
         for key, group in groupby(
             sorted(self.paths_to_docx_files, key=AhbFileFinder.get_first_part_of_ahb_docx_file_name),
             AhbFileFinder.get_first_part_of_ahb_docx_file_name,


### PR DESCRIPTION
Communication over instance variables is not a good idea.
What happened is:
- several methods apply filters / write to `AhbFileFinder.paths_to_docx_files`
- but when the search algorithm starts over again at filter_for_latest_ahb_docx_files the list was _not_ repopulated with all pathes, instead the already filtered list was re-used