### PR TITLE
chore: drop `pip-compile step` from dev env setup; Add `pip-compile-multi` env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,9 +64,14 @@ deps =
     pre-commit
 commands =
     python -m pip install --upgrade pip
-    pip-compile pyproject.toml
     pip install -r requirements.txt
     pre-commit install
+
+[testenv:compile_requirements]
+deps =
+    pip-compile-multi
+commands =
+    pip-compile-multi -d dev_requirements --autoresolve
 
 [testenv:test_packaging]
 skip_install = true


### PR DESCRIPTION

dropping pip-compile leads to better reproducability