### PR TITLE
Fix regression: Treat empty string `''` as `None` data element ID

### DIFF
--- a/src/kohlrahbi/unfoldedahb/unfoldedahbtable.py
+++ b/src/kohlrahbi/unfoldedahb/unfoldedahbtable.py
@@ -46,7 +46,7 @@ def _split_data_element_and_segment_id(value: str | None) -> tuple[str | None, s
     """
     returns the data element id and segment id
     """
-    if value is None:
+    if not value:  # covers both None and empty string
         return None, None
     datenelement_id: str | None
     segment_id: str | None


### PR DESCRIPTION
fixes:
> ERROR    [kohlrahbi] Could not convert the unfolded AHB to a flat AHB for Prüfidentifikator '15003'
ERROR    [kohlrahbi] Error processing pruefi '15003': The data_element '' does not match re.compile('^\\d{4}$')

introduced in v1.1.0