### PR TITLE
ci(gh action): Add check for conventional commit in PR title

### DIFF
--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -1,0 +1,15 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/PRConventionalCommits@1.1.0
+        with:
+          task_types: '["feat","fix","docs","style","refactor","perf","test","build","ci","chore","revert"]'
+          add_label: 'false'


### PR DESCRIPTION
This PR will introduce a check to enforce [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

There is a nice [cheat-sheet for conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index).