### PR TITLE
feat(quality map): Add Command To Scrape Quality Map

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pandas==2.2.3
     # via kohlrahbi (pyproject.toml)
 pydantic==2.9.2
     # via kohlrahbi (pyproject.toml)
-pydantic-core==2.24.0
+pydantic-core==2.23.4
     # via pydantic
 python-dateutil==2.9.0.post0
     # via pandas

--- a/src/kohlrahbi/__init__.py
+++ b/src/kohlrahbi/__init__.py
@@ -7,6 +7,7 @@ import click
 from kohlrahbi.ahb.command import ahb
 from kohlrahbi.changehistory.command import changehistory
 from kohlrahbi.conditions.command import conditions
+from kohlrahbi.qualitymap.command import qualitymap
 from kohlrahbi.version import version
 
 
@@ -20,6 +21,7 @@ def cli() -> None:
 cli.add_command(ahb)
 cli.add_command(changehistory)
 cli.add_command(conditions)
+cli.add_command(qualitymap)
 
 if __name__ == "__main__":
     # the parameter arguments gets provided over the CLI

--- a/src/kohlrahbi/docxfilefinder.py
+++ b/src/kohlrahbi/docxfilefinder.py
@@ -215,3 +215,16 @@ class DocxFileFinder(BaseModel):
         self.remove_temporary_files()
 
         return self.paths_to_docx_files
+
+    def get_docx_files_which_contain_quality_map(self) -> list[Path]:
+        """
+        This function returns a list of docx files which contain a quality map.
+        """
+
+        self.filter_for_latest_ahb_docx_files()
+        self.remove_temporary_files()
+
+        indicator_string = "UTILMDAHBStrom"
+        self.paths_to_docx_files = [path for path in self.paths_to_docx_files if indicator_string in path.name]
+
+        return self.paths_to_docx_files

--- a/src/kohlrahbi/qualitymap/__init__.py
+++ b/src/kohlrahbi/qualitymap/__init__.py
@@ -43,7 +43,7 @@ def get_quality_map_table(document: Document) -> Optional[QualityMapTable]:
     # Iterate through the whole word document
     logger.info("🔁 Start iterating through paragraphs and tables")
     for table in document.tables:
-        if isinstance(table, Table) and is_quality_map_table(table=table):
+        if is_quality_map_table(table=table):
             change_history_table = QualityMapTable.from_docx_quality_map_table(docx_table=table)
             return change_history_table
 

--- a/src/kohlrahbi/qualitymap/__init__.py
+++ b/src/kohlrahbi/qualitymap/__init__.py
@@ -66,7 +66,15 @@ def process_docx_file(file_path: Path) -> Optional[QualityMapTable]:
 def scrape_quality_map(input_path: Path, output_path: Path) -> None:
     """
     starts the scraping process of the quality maps.
+
+    Args:
+        input_path (Path): The path to the input **directory** containing the docx files with quality maps.
+        output_path (Path): The path to the output **directory** to save the scraped quality maps
     """
+    if input_path.is_dir() is False:
+        logger.error("The input path '%s' is not a directory.", input_path)
+        raise NotADirectoryError(f"The input path '{input_path}' is not a directory.")
+
     logger.info("👀 Start looking for quality maps")
     ahb_file_paths = find_docx_files(input_path)
 

--- a/src/kohlrahbi/qualitymap/__init__.py
+++ b/src/kohlrahbi/qualitymap/__init__.py
@@ -18,10 +18,10 @@ from kohlrahbi.read_functions import get_all_paragraphs_and_tables
 
 def find_docx_files(input_path: Path) -> list[Path]:
     """
-    Find all .docx files containing change histories.
+    Find all .docx files containing quality maps.
     """
     docx_file_finder = DocxFileFinder.from_input_path(input_path=input_path)
-    return docx_file_finder.get_all_docx_files_which_contain_change_histories()
+    return docx_file_finder.get_docx_files_which_contain_quality_map()
 
 
 def is_quality_map_table(table: Table) -> bool:
@@ -65,12 +65,11 @@ def process_docx_file(file_path: Path) -> Optional[QualityMapTable]:
 
 def scrape_quality_map(input_path: Path, output_path: Path) -> None:
     """
-    starts the scraping process of the change histories
+    starts the scraping process of the quality maps.
     """
-    logger.info("👀 Start looking for change histories")
+    logger.info("👀 Start looking for quality maps")
     ahb_file_paths = find_docx_files(input_path)
 
-    # change_history_collection = {}
     for file_path in ahb_file_paths:
         quality_map_table = process_docx_file(file_path)
         logger.info("Done with %s", file_path)

--- a/src/kohlrahbi/qualitymap/__init__.py
+++ b/src/kohlrahbi/qualitymap/__init__.py
@@ -1,0 +1,77 @@
+"""
+This module contains the functions to scrape the AHBs for quality maps.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import docx
+import pandas as pd
+from docx.document import Document
+from docx.table import Table
+
+from kohlrahbi.docxfilefinder import DocxFileFinder
+from kohlrahbi.logger import logger
+from kohlrahbi.qualitymap.qualitymaptable import QualityMapTable
+from kohlrahbi.read_functions import get_all_paragraphs_and_tables
+
+
+def find_docx_files(input_path: Path) -> list[Path]:
+    """
+    Find all .docx files containing change histories.
+    """
+    docx_file_finder = DocxFileFinder.from_input_path(input_path=input_path)
+    return docx_file_finder.get_all_docx_files_which_contain_change_histories()
+
+
+def is_quality_map_table(table: Table) -> bool:
+    """
+    Checks if the given table is quality map table.
+    """
+    try:
+        return table.cell(row_idx=0, col_idx=0).text.strip() == "Änd-ID"
+    except IndexError:
+        return False
+
+
+def get_quality_map_table(document: Document) -> Optional[QualityMapTable]:
+    """
+    Reads a docx file and extracts the quality map table.
+    Returns None if no such table was found.
+    """
+
+    # Iterate through the whole word document
+    logger.info("🔁 Start iterating through paragraphs and tables")
+    for item in get_all_paragraphs_and_tables(parent=document):
+        if isinstance(item, Table) and is_quality_map_table(table=item):
+            change_history_table = QualityMapTable.from_docx_quality_map_table(docx_table=item)
+            return change_history_table
+
+    return None
+
+
+def process_docx_file(file_path: Path) -> Optional[pd.DataFrame]:
+    """
+    Read and process quality map from a .docx file.
+    """
+    doc = docx.Document(str(file_path))
+    logger.info("🤓 Start reading docx file '%s'", str(file_path))
+    quality_map_table = get_quality_map_table(document=doc)
+
+    if quality_map_table is not None:
+        # quality_map_table.sanitize_table()
+        return quality_map_table.table
+    return None
+
+
+def scrape_quality_map(input_path: Path, output_path: Path) -> None:
+    """
+    starts the scraping process of the change histories
+    """
+    logger.info("👀 Start looking for change histories")
+    ahb_file_paths = find_docx_files(input_path)
+
+    # change_history_collection = {}
+    for file_path in ahb_file_paths:
+        df = process_docx_file(file_path)
+        logger.info("Done with %s", file_path)

--- a/src/kohlrahbi/qualitymap/__init__.py
+++ b/src/kohlrahbi/qualitymap/__init__.py
@@ -82,7 +82,7 @@ def scrape_quality_map(input_path: Path, output_path: Path) -> None:
         quality_map_table = process_docx_file(file_path)
         logger.info("Done with %s", file_path)
         if quality_map_table is None:
-            logger.warning("No quality map table found in %s", file_path)
+            logger.info("No quality map table found in %s", file_path)
             continue
         quality_map_table.save_to_csv(output_path / Path(f"{file_path.stem}_quality_map.csv"))
         quality_map_table.save_to_xlsx(output_path / Path(f"{file_path.stem}_quality_map.xlsx"))

--- a/src/kohlrahbi/qualitymap/__init__.py
+++ b/src/kohlrahbi/qualitymap/__init__.py
@@ -42,9 +42,9 @@ def get_quality_map_table(document: Document) -> Optional[QualityMapTable]:
 
     # Iterate through the whole word document
     logger.info("🔁 Start iterating through paragraphs and tables")
-    for item in get_all_paragraphs_and_tables(parent=document):
-        if isinstance(item, Table) and is_quality_map_table(table=item):
-            change_history_table = QualityMapTable.from_docx_quality_map_table(docx_table=item)
+    for table in document.tables:
+        if isinstance(table, Table) and is_quality_map_table(table=table):
+            change_history_table = QualityMapTable.from_docx_quality_map_table(docx_table=table)
             return change_history_table
 
     return None

--- a/src/kohlrahbi/qualitymap/__init__.py
+++ b/src/kohlrahbi/qualitymap/__init__.py
@@ -29,7 +29,7 @@ def is_quality_map_table(table: Table) -> bool:
     Checks if the given table is quality map table.
     """
     try:
-        return table.cell(row_idx=0, col_idx=0).text.strip() == "Änd-ID"
+        return table.cell(row_idx=0, col_idx=0).text.strip() == "Qualität\n\nSegmentgruppe"
     except IndexError:
         return False
 
@@ -50,7 +50,7 @@ def get_quality_map_table(document: Document) -> Optional[QualityMapTable]:
     return None
 
 
-def process_docx_file(file_path: Path) -> Optional[pd.DataFrame]:
+def process_docx_file(file_path: Path) -> Optional[QualityMapTable]:
     """
     Read and process quality map from a .docx file.
     """
@@ -59,8 +59,7 @@ def process_docx_file(file_path: Path) -> Optional[pd.DataFrame]:
     quality_map_table = get_quality_map_table(document=doc)
 
     if quality_map_table is not None:
-        # quality_map_table.sanitize_table()
-        return quality_map_table.table
+        return quality_map_table
     return None
 
 
@@ -73,5 +72,10 @@ def scrape_quality_map(input_path: Path, output_path: Path) -> None:
 
     # change_history_collection = {}
     for file_path in ahb_file_paths:
-        df = process_docx_file(file_path)
+        quality_map_table = process_docx_file(file_path)
         logger.info("Done with %s", file_path)
+        if quality_map_table is None:
+            logger.warning("No quality map table found in %s", file_path)
+            continue
+        quality_map_table.save_to_csv(output_path / Path(f"{file_path.stem}_quality_map.csv"))
+        quality_map_table.save_to_xlsx(output_path / Path(f"{file_path.stem}_quality_map.xlsx"))

--- a/src/kohlrahbi/qualitymap/command.py
+++ b/src/kohlrahbi/qualitymap/command.py
@@ -1,0 +1,65 @@
+"""
+Command line interface for the qualitymap command.
+"""
+
+from pathlib import Path
+
+import click
+from efoli import EdifactFormatVersion
+
+from kohlrahbi.ahb.command import check_python_version, validate_path
+from kohlrahbi.qualitymap import scrape_quality_map
+
+
+@click.command()
+@click.option(
+    "-eemp",
+    "--edi-energy-mirror-path",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, resolve_path=True, path_type=Path),
+    help="The root path to the edi_energy_mirror repository.",
+    required=True,
+)
+@click.option(
+    "-o",
+    "--output-path",
+    type=click.Path(exists=False, dir_okay=True, file_okay=False, resolve_path=True, path_type=Path),
+    callback=validate_path,
+    default="output",
+    prompt="Output directory",
+    help="Define the path where you want to save the generated files.",
+)
+@click.option(
+    "--format-version",
+    multiple=False,
+    type=click.Choice([e.value for e in EdifactFormatVersion], case_sensitive=False),
+    help="Format version(s) of the AHB documents, e.g. FV2310",
+)
+@click.option(
+    "--assume-yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Confirm all prompts automatically.",
+)
+def qualitymap(
+    edi_energy_mirror_path: Path,
+    output_path: Path,
+    format_version: EdifactFormatVersion | str,
+    assume_yes: bool,  # pylint: disable=unused-argument
+    # it is used by the callback function of the output-path
+) -> None:
+    """
+    Scrape quality map from the input path and save them to the output path.
+
+    Args:
+        edi_energy_mirror_path (Path): The path to the input file or directory containing change histories.
+        output_path (Path): The path to save the scraped change histories.
+        format_version (EdifactFormatVersion | str): The version of the EDIFACT format to use for scraping.
+            Can be either an instance of EdifactFormatVersion or a string representation of the version.
+        assume_yes (bool): Flag indicating whether to assume "yes" for all prompts.
+    """
+    check_python_version()
+    if isinstance(format_version, str):
+        format_version = EdifactFormatVersion(format_version)
+    input_path = edi_energy_mirror_path / "edi_energy_de" / format_version.value
+    scrape_quality_map(input_path=input_path, output_path=output_path)

--- a/src/kohlrahbi/qualitymap/qualitymaptable.py
+++ b/src/kohlrahbi/qualitymap/qualitymaptable.py
@@ -15,6 +15,17 @@ from kohlrahbi.logger import logger
 class QualityMapTable(BaseModel):
     """
     This class contains the quality map table.
+
+    Die SG für die Datenübermittlung haben in den Segmenten DE1153 SG6 RFF, DE1229 SG8 SEQ und DE3035 SG12 NAD
+    verschiedene Codes, die die Qualität der enthaltenen Daten festlegen.
+    Die Qualitätsstufen sind:
+        •   Bestellte Daten: Konfiguration, die der Absender beim Empfänger bestellt.
+        •   Gültige Daten: Verbindliche Stammdaten, die vom Verantwortlichen bereitgestellt und
+                           vom Berechtigten übernommen werden müssen.
+        •   Informative Daten: Datenstand des Absenders zum Zeitpunkt der Nachricht, ohne Gültigkeitszeitraum, nur zur Information im entsprechenden Use-Case.
+        •   Erwartete Daten: Erwartung des Berechtigten, nur für Abrechnungsdaten, Stammdatenänderungen und
+                             Datenclearing relevant.
+        •   Im System vorhandene Daten: Datenstand des Berechtigten, ausschließlich für das Datenclearing.
     """
 
     table: pd.DataFrame

--- a/src/kohlrahbi/qualitymap/qualitymaptable.py
+++ b/src/kohlrahbi/qualitymap/qualitymaptable.py
@@ -22,7 +22,8 @@ class QualityMapTable(BaseModel):
         •   Bestellte Daten: Konfiguration, die der Absender beim Empfänger bestellt.
         •   Gültige Daten: Verbindliche Stammdaten, die vom Verantwortlichen bereitgestellt und
                            vom Berechtigten übernommen werden müssen.
-        •   Informative Daten: Datenstand des Absenders zum Zeitpunkt der Nachricht, ohne Gültigkeitszeitraum, nur zur Information im entsprechenden Use-Case.
+        •   Informative Daten: Datenstand des Absenders zum Zeitpunkt der Nachricht, ohne Gültigkeitszeitraum,
+                               nur zur Information im entsprechenden Use-Case.
         •   Erwartete Daten: Erwartung des Berechtigten, nur für Abrechnungsdaten, Stammdatenänderungen und
                              Datenclearing relevant.
         •   Im System vorhandene Daten: Datenstand des Berechtigten, ausschließlich für das Datenclearing.

--- a/src/kohlrahbi/qualitymap/qualitymaptable.py
+++ b/src/kohlrahbi/qualitymap/qualitymaptable.py
@@ -1,0 +1,41 @@
+"""
+This module provides the QualityMapTable class
+"""
+
+import pandas as pd
+from docx.table import Table
+from pydantic import BaseModel, ConfigDict
+
+from kohlrahbi.ahbtable.ahbsubtable import AhbSubTable
+
+
+class QualityMapTable(BaseModel):
+    """
+    This class contains the quality map table.
+    """
+
+    table: pd.DataFrame
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @classmethod
+    def from_docx_quality_map_table(cls, docx_table: Table) -> "QualityMapTable":
+        """
+        Create a QualityMapTable object from a quality map table.
+        """
+
+        quality_map_rows: list[list[str]] = []
+
+        for row in docx_table.rows:
+            sanitized_cells = list(AhbSubTable.iter_visible_cells(row=row))
+
+            is_header_row = sanitized_cells[0].text == "Änd-ID" or sanitized_cells[2].text == "Bisher"
+            if is_header_row:
+                continue
+            quality_map_rows.append([cell.text for cell in sanitized_cells])
+
+        headers = ["Änd-ID", "Ort", "Änderungen Bisher", "Änderungen Neu", "Grund der Anpassung", "Status"]
+
+        df = pd.DataFrame(quality_map_rows, columns=headers)
+
+        return cls(table=df)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv = PYTHONPATH = {toxinidir}/src
 deps =
     .[test]
 commands =
-    coverage run -m pytest --basetemp={envtmpdir} {posargs}
+    coverage run -m pytest --durations=0 --basetemp={envtmpdir} {posargs}
     coverage html --omit .tox/*,unittests/*
     coverage report --fail-under 85 --omit .tox/*,unittests/*
 

--- a/unittests/__snapshots__/test_quality_map.ambr
+++ b/unittests/__snapshots__/test_quality_map.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestQualityMap.test_cli_quality_map_table[check]
+# name: TestQualityMap.test_cli_quality_map_table[check command for quality map table]
   '''
   Qualität \ Segmentgruppe,Bestellte Daten,Gültige Daten,Informative Daten,Erwartete Daten,Im System vorhandene Daten
   "SG6 RFF DE1153 

--- a/unittests/__snapshots__/test_quality_map.ambr
+++ b/unittests/__snapshots__/test_quality_map.ambr
@@ -1,0 +1,380 @@
+# serializer version: 1
+# name: TestQualityMap.test_cli_quality_map_table[check]
+  '''
+  Qualität \ Segmentgruppe,Bestellte Daten,Gültige Daten,Informative Daten,Erwartete Daten,Im System vorhandene Daten
+  "SG6 RFF DE1153 
+  Termine der Marktlokation",--,"Z50
+  „Termindaten der Marktlokation“",--,"Z51
+  „Erwartete Termindaten der Marktlokation“","Z52
+  „Im System vorhandene Termindaten der Marktlokation“"
+  "SG8 SEQ DE1229
+  Referenz auf die Lokationsbündelstruktur",--,"Z78
+  „Referenz auf die Lokationsbündelstruktur“","ZD5
+  „Informative Referenz auf die Lokationsbündelstruktur“","ZC7
+  „Erwartete Referenz auf die Lokationsbündelstruktur“","ZC8
+  „Im System vorhandene Referenz auf die Lokationsbündelstruktur“"
+  "SG8 SEQ DE1229
+  Objektcode der Lokation in der Lokationsbündelstruktur",--,"Z58
+  „Zuordnung Lokation zum Objektcode des Lokationsbündels“","ZD6
+  „Informative Zuordnung Lokation zum Objektcode des Lokationsbündels“","ZC9
+  „Erwartete Zuordnung Lokation zum Objektcode des Lokationsbündels“","ZD0
+  „Im System vorhandene Zuordnung Lokation zum Objektcode des Lokationsbündels“"
+  "SG8 SEQ DE1229
+  Bestandteil eines Produktpakets","Z79
+  „Bestandteil eines Produktpakets“",--,--,--,--
+  "SG8 SEQ DE1229
+  Priorisierung erforderliches Produktpaket","ZH0
+  „Priorisierung erforderliches Produktpaket“",--,--,--,--
+  "SG8 SEQ DE1229
+  Daten der Netzlokation",--,"Z51 
+  „Daten der Netzlokation“","ZD7 
+  „Informative Daten der Netzlokation“","ZA9 
+  „Erwartete Daten der Netzlokation“","ZB0 
+  „Im System vorhandene Daten der Netzlokation“"
+  "SG8 SEQ DE1229
+  Abrechnungsdaten der Netzlokation",--,"Z71
+  „Abrechnungsdaten der Netzlokation“","ZD8
+  „Informative Abrechnungsdaten der
+  Netzlokation“","ZH1 
+  „Erwartete Abrechnungsdaten der Netzlokation“","ZH2 
+  „Im System vorhandene Abrechnungsdaten der Netzlokation“"
+  "SG8 SEQ DE1229
+  OBIS-Daten der Netzlokation",--,"Z57
+  „OBIS-Daten der Netzlokation“","ZD9
+  „Informative OBIS-Daten der Netzlokation“","ZA7
+  „Erwartete OBIS-Daten der Netzlokation“","ZA8
+  „Im System vorhandene OBIS-Daten der
+  Netzlokation“"
+  "SG8 SEQ DE1229
+  Produkt-Daten der Netzlokation",--,"Z60
+  „Produkt-Daten der Netzlokation“","ZE0
+  „Informative Produkt-Daten der Netzlokation“","ZG8
+  „Erwartete Produkt-Daten der NeLo“","ZG9
+  „Im System vorhandene Produkt-Daten der
+  NeLo“"
+  "SG8 SEQ DE1229
+  Daten der Marktlokation",--,"Z01
+  „Daten der Marktlokation“","Z98
+  „Informative Daten der Marktlokation“","Z80
+  „Erwartete Daten der Marktlokation“","Z81
+  „Im System vorhandene Daten der
+  Marktlokation“"
+  "SG8 SEQ DE1229
+  Daten der Marktlokation der beteiligten Marktrolle",--,--,--,--,"Z29
+  „Daten der Marktlokation der beteiligten
+  Marktrolle“"
+  "SG8 SEQ DE1229
+  Netznutzungsabrechnungsdaten der Marktlokation",--,"Z45
+  „Netznutzungsabrechnungsdaten der
+  Marktlokation“
+  
+  Z84
+  „Differenz-Netznutzungsabrechnungsdaten der
+  Marktlokation“","ZE1 
+  „Informative Netznutzungsabrechnungsdaten
+  der Marktlokation“","Z82
+  „Erwartete Netznutzungsabrechnungsdaten der
+  Marktlokation“
+  
+  Z96 
+  „Erwartete Differenz-
+  Netznutzungsabrechnungsdaten der
+  Marktlokation“","Z83 
+  „Im System vorhandene
+  Netznutzungsabrechnungsdaten der
+  Marktlokation“
+  
+  Z97 
+  „Im System vorhandene Differenz-
+  Netznutzungsabrechnungsdaten der
+  Marktlokation“"
+  "SG8 SEQ DE1229
+  Messstellenbetriebsabrechnungsdaten der Marktlokation",--,"Z76
+  „Messstellenbetriebsabrechnungsdaten der
+  Marktlokation“
+  ",--,"ZC5
+  „Erwartete
+  Messstellenbetriebsabrechnungsdaten der
+  Marktlokation“","ZC6
+  „Im System vorhandene
+  Messstellenbetriebsabrechnungsdaten der
+  Marktlokation“"
+  "SG8 SEQ DE1229
+  Erforderliches Messprodukt der Marktlokation","Z27
+  „Erforderliches Messprodukt der Marktlokation“",--,"ZE2
+  „Informative Erforderliches Messprodukt der
+  Marktlokation“",--,--
+  "SG8 SEQ DE1229
+  OBIS-Daten der Marktlokation",--,"Z02
+  „OBIS-Daten der Marktlokation“","ZE3
+  „Informative OBIS-Daten der Marktlokation“","ZA1
+  „Erwartete OBIS-Daten der Marktlokation“","ZA2
+  „Im System vorhandene OBIS-Daten der
+  Marktlokation“"
+  "SG8 SEQ DE1229
+  Produkt-Daten der Marktlokation",--,"Z59
+  „Produkt-Daten der Marktlokation“","ZE4
+  „Informative Produkt-Daten der Marktlokation“","ZB5
+  „Erwartete Produkt-Daten der Marktlokation“","ZB6
+  „Im System vorhandene Produkt-Daten der
+  Marktlokation“"
+  "SG8 SEQ DE1229
+  Verbrauchsart und Nutzung der OBIS-Kennzahl an der Marktlokation",--,"Z44
+  „Verbrauchsart und Nutzung der OBIS-Kennzahl
+  an der Marktlokation“","ZE5
+  „Informative Verbrauchsart und Nutzung der
+  OBIS-Kennzahl an der Marktlokation“","ZD1
+  „Erwartete Verbrauchsart und Nutzung der
+  OBIS-Kennzahl der Marktlokation“","ZD2
+  „Im System vorhandene Verbrauchsart und
+  Nutzung der OBIS-Kennzahl der Marktlokation“"
+  "SG8 SEQ DE1229
+  OBIS-Daten der Marktlokation der beteiligten Marktrolle",--,--,--,--,"Z30
+  „OBIS-Daten der Marktlokation der beteiligten
+  Marktrolle“"
+  "SG8 SEQ DE1229
+  Produkt-Daten der Marktlokation des NB",--,"Z40
+  „Produkt-Daten der Marktlokation des NB“","ZE6
+  „Informative Produkt-Daten der Marktlokation
+  des NB“","ZD3
+  „Erwartete Produkt-Daten der Marktlokation
+  des NB“","ZD4
+  „Im System vorhandene Produkt-Daten der
+  Marktlokation des NB“"
+  "SG8 SEQ DE1229
+  Daten der Tranche",--,"Z15
+  „Daten der Tranche“","ZE7
+  „Informative Daten der Tranche“","Z94
+  „Erwartete Daten der Tranche“","Z95
+  „Im System vorhandene Daten der Tranche“"
+  "SG8 SEQ DE1229
+  Daten der Tranche der beteiligten Marktrolle",--,--,--,--,"Z31
+  „Daten der Tranche der beteiligten Marktrolle“"
+  "SG8 SEQ DE1229
+  Erforderliches Messprodukt der Tranche","Z16
+  „Erforderliches Produkt der Tranche“",--,"ZE8
+  „Informative Erforderliches Produkt der
+  Tranche“",--,--
+  "SG8 SEQ DE1229
+  OBIS-Daten der Tranche",--,"Z17
+  „OBIS-Daten der Tranche“","ZE9
+  „Informative OBIS-Daten der Tranche“","Z99
+  „Erwartete OBIS-Daten der Tranche“","ZA0
+  „Im System vorhandene OBIS-Daten der
+  Tranche“"
+  "SG8 SEQ DE1229
+  OBIS-Daten der Tranche der beteiligten Marktrolle",--,--,--,--,"Z32
+  „OBIS-Daten der Tranche der beteiligten
+  Marktrolle“"
+  "SG8 SEQ DE1229
+  Daten der Technischen Ressource",--,"Z52
+  „Daten der Technischen Ressource“","ZF0
+  „Informative Daten der Technischen Ressource“","ZG4
+  „Erwartete Daten der Technischen Ressource“","ZG5
+  „Im System vorhandene Daten der Technischen
+  Ressource“"
+  "SG8 SEQ DE1229
+  Daten der Steuerbaren Ressource",--,"Z62
+  „Daten der Steuerbaren Ressource“","ZF1
+  „Informative Daten der Steuerbaren Ressource“","ZB1
+  „Erwartete Daten der Steuerbaren Ressource“","ZB2
+  „Im System vorhandene Daten der Steuerbaren Ressource“"
+  "SG8 SEQ DE1229
+  Produkt-Daten der Steuerbaren Ressource",--,"Z61
+  „Produkt-Daten der Steuerbaren Ressource“","ZF2
+  „Informative Produkt-Daten der Steuerbaren
+  Ressource“","ZB3
+  „Erwartete Produkt-Daten der Steuerbaren
+  Ressource“","ZB4
+  „Im System vorhandene Produkt-Daten der
+  Steuerbaren Ressource“"
+  "SG8 SEQ DE1229
+  Daten der Messlokation",--,"Z18
+  „Daten der Messlokation“","ZF3
+  „Informative Daten der Messlokation“","ZG6
+  „Erwartete Daten der Messlokation“","ZG7
+  „Im System vorhandene Daten der
+  Messlokation“"
+  "SG8 SEQ DE1229
+  Erforderliches Messprodukt der Messlokation","Z19
+  „Erforderliches Produkt der Messlokation“",--,"ZF4
+  „Informative Erforderliches Produkt der
+  Messlokation“",--,--
+  "SG8 SEQ DE1229
+  Zähleinrichtungsdaten",--,"Z03
+  „Zähleinrichtungsdaten“","ZF5
+  „Informative Zähleinrichtungsdaten“","ZA3
+  „Erwartete Zähleinrichtungsdaten“","ZA4
+  „Im System vorhandene Zähleinrichtungsdaten“"
+  "SG8 SEQ DE1229
+  OBIS-Daten der Zähleinrichtung / Smartmeter-Gateway",--,"Z20
+  „OBIS-Daten der Zähleinrichtung“","ZF6
+  „Informative OBIS-Daten der Zähleinrichtung“","ZA5
+  „Erwartete OBIS-Daten der Zähleinrichtung“","ZA6
+  „Im System vorhandene OBIS-Daten der
+  Zähleinrichtung“"
+  "SG8 SEQ DE1229
+  Wandlerdaten",--,"Z04
+  „Wandlerdaten“","ZF7
+  „Informative Wandlerdaten“","ZB9
+  „Erwartete Wandlerdaten“","ZC0
+  „Im System vorhandene Wandlerdaten“"
+  "SG8 SEQ DE1229
+  Kommunikationseinrichtungsdaten",--,"Z05
+  „Kommunikationseinrichtungsdaten“","ZF8
+  „Informative
+  Kommunikationseinrichtungsdaten“","ZB7
+  „Erwartete Kommunikationseinrichtungsdaten“","ZB8
+  „Im System vorhandene
+  Kommunikationseinrichtungsdaten“"
+  "SG8 SEQ DE1229
+  Daten der technischen Steuereinrichtung",--,"Z06
+  „Daten der technischen Steuereinrichtung“","ZF9
+  „Informative Daten der technischen
+  Steuereinrichtung“","ZC1
+  „Erwartete Daten der technischen
+  Steuereinrichtung“","ZC2
+  „Im System vorhandene Daten der technischen
+  Steuereinrichtung“"
+  "SG8 SEQ DE1229
+  Smartmeter-Gateway",--,"Z13
+  „Smartmeter-Gateway“","ZG0
+  „Informative Smartmeter-Gateway“","ZC3
+  „Erwartetes Smartmeter-Gateway“","ZC4
+  „Im System vorhandenes Smartmeter-Gateway“"
+  "SG8 SEQ DE1229
+  Daten der Steuerbox",--,"Z14
+  „Steuerbox“",--,"ZH3 
+  „Erwartete Daten der Steuerbox“","ZH4
+  „Im System vorhandene Daten der Steuerbox“"
+  "SG8 SEQ DE1229
+  Profildaten",--,"Z21
+  „Profildaten“","ZG1
+  „Informative Profildaten“","Z85
+  „Erwartete Profildaten“","Z86
+  „Im System vorhandene Profildaten“"
+  "SG8 SEQ DE1229
+  Profildaten der beteiligten Marktrolle",--,--,--,--,"Z33
+  „Profildaten der beteiligten Marktrolle“"
+  "SG8 SEQ DE1229
+  Profilschardaten",--,"Z08
+  „Profilschardaten“","ZG2
+  „Informative Profilschardaten“","Z87
+  „Erwartete Profilschardaten“","Z88
+  „Im System vorhandene Profilschardaten“"
+  "SG8 SEQ DE1229
+  Referenzprofildaten",--,"Z38
+  „Referenzprofildaten“","ZG3
+  „Informative Referenzprofildaten“","Z89
+  „Erwartete Referenzprofildaten“","Z90
+  „Im System vorhandene Referenzprofildaten“"
+  "SG8 SEQ DE1229
+  Daten der Summenzeitreihe",--,"Z22
+  „Daten der Summenzeitreihe“",--,--,--
+  "SG8 SEQ DE1229
+  Produkt-Daten der Summenzeitreihe",--,"Z23
+  „Produkt-Daten der Summenzeitreihe“",--,--,--
+  "SG8 SEQ DE1229
+  „Daten der Überführungszeitreihe“",--,"Z24
+  „Daten der Überführungszeitreihe“",--,--,--
+  "SG8 SEQ DE1229
+  Produkt-Daten der Überführungszeitreihe",--,"Z25
+  „Produkt-Daten der Überführungszeitreihe“",--,--,--
+  "SG8 SEQ DE1229
+  Datenstand des ÜNB",--,--,--,--,"Z47
+  „Datenstand des ÜNB“"
+  "SG8 SEQ DE1229
+  Datenstand des NB",--,--,--,--,"Z72
+  „Datenstand des NB“"
+  "SG8 SEQ DE1229
+  Abgerechnete Daten der
+  Bilanzkreissummenzeitreihe",--,"Z48
+  „Abgerechnete Daten der
+  Bilanzkreissummenzeitreihe des ÜNB“",--,--,--
+  "SG8 SEQ DE1229
+  Abgerechnete Daten der
+  Bilanzierungsgebietssummenzeitreihe",--,"Z49
+  „Abgerechnete Daten der
+  Bilanzierungsgebietssummenzeitreihe des
+  ÜNB“",--,--,--
+  "SG8 SEQ DE1229
+  Daten des Kunden des Lieferanten",--,"Z75
+  „Daten des Kunden des Lieferanten“",--,"Z92
+  „Erwartete Daten des Kunden des Lieferanten“","Z93
+  „Im System vorhandene Daten des Kunden des
+  Lieferanten“"
+  "SG12 NAD DE3035
+  Kunde des Lieferanten",--,"Z09
+  „Kunde des LF“","Z65
+  „Informativer Kunden des LF“","Z47
+  „Erwarteter Kunde des LF“","Z48
+  „Im System vorhandener Kunde des LF“"
+  "SG12 NAD DE3035
+  Korrespondenzanschrift des Kunden des Lieferanten",--,"Z04
+  „Korrespondenzanschrift des Kunden des LF“","Z66
+  „Informative Korrespondenzanschrift des Kunden des LF“","Z49
+  „Erwartete Korrespondenzanschrift des Kunden des LF“","Z50
+  „Im System vorhandene
+  Korrespondenzanschrift des Kunden des LF“"
+  "SG12 NAD DE3035
+  Kunde des Messstellenbetreibers",--,"Z07
+  „Kunde des MSB“",--,"Z39
+  „Erwarteter Kunde des MSB“","Z40
+  „Im System vorhandener Kunde des MSB“"
+  "SG12 NAD DE3035
+  Korrespondenzanschrift des Kunden des Messstellenbetreibers",--,"Z08
+  „Korrespondenzanschrift des Kunden des MSB“",--,"Z41
+  „Erwartete Korrespondenzanschrift des Kunden des MSB“","Z42
+  „Im System vorhandene
+  Korrespondenzanschrift des Kunden des MSB“"
+  "SG12 NAD DE3035
+  Kunde des Netzbetreibers",--,"Z25
+  „Kunde des NB“","Z67
+  „Informativer Kundenname des NB“","Z51
+  „Erwarteter Kunde des Netzbetreibers“","Z52
+  „Im System vorhandener Kunde des
+  Netzbetreibers“"
+  "SG12 NAD DE3035
+  Korrespondenzanschrift des Kunden des Netzbetreibers",--,"Z26
+  „Korrespondenzanschrift des Kunden des NB“","Z68
+  „Informative Korrespondenzanschrift des Kunde des NB“","Z53
+  „Erwartete Korrespondenzanschrift des Kunden des Netzbetreibers“","Z54
+  „Im System vorhandene
+  Korrespondenzanschrift des Kunden des Netzbetreibers“"
+  "SG12 NAD DE3035
+  Anschlussnehmer",--,"EO
+  „Anschlussnehmer“","Z69
+  „Informative Daten des Anschlussnehmers“","Z55
+  „Erwarteter Anschlussnehmer“","Z56
+  „Im System vorhandener Anschlussnehmer“"
+  "SG12 NAD DE3035
+  Beteiligter Marktpartner MP-ID",--,--,"VY
+  „andere zugehörige Partei“",--,--
+  "SG12 NAD DE3035
+  Hausverwalter",--,"DDO
+  „Hausverwalter“
+  ","Z70
+  „Informative Daten des Hausverwalters“","Z57
+  „Erwarteter Hausverwalter“","Z58
+  „Im System vorhandener Hausverwalter“"
+  "SG12 NAD DE3035
+  Marktlokationsanschrift",--,"DP
+  „Lieferanschrift“","Z63
+  „Informative Marktlokationsanschrift“","Z59
+  „Erwartete Marktlokationsanschrift“","Z60
+  „Im System vorhandene
+  Marktlokationsanschrift“"
+  "SG12 NAD DE3035
+  Messlokationsadresse",--,"Z03
+  „Messlokationsadresse“","Z64
+  „Informative Messlokationsadresse“","Z43
+  „Erwartete Messlokationsadresse“","Z44
+  „Im System vorhandene Messlokationsadresse“"
+  "SG12 NAD DE3035
+  Name und Adresse für die Ablesekarte",--,"Z05
+  „Name und Adresse für die Ablesekarte“",--,"Z45
+  „Erwarteter Name und Adresse für die Ablesekarte“","Z46
+  „Im System vorhandener Name und Adresse für die Ablesekarte“"
+  
+  '''
+# ---

--- a/unittests/cellparagraph.py
+++ b/unittests/cellparagraph.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from docx.shared import Length
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class CellParagraph(BaseModel):
@@ -18,8 +18,7 @@ class CellParagraph(BaseModel):
     tabstop_positions: Optional[list[Length]] = Field(None)
     left_indent_length: Length = Field(...)
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @model_validator(mode="after")
     def check_text(self):

--- a/unittests/test_ahb.py
+++ b/unittests/test_ahb.py
@@ -3,12 +3,7 @@ from pathlib import Path
 import pytest
 from freezegun import freeze_time
 
-from kohlrahbi.ahb import (
-    extract_pruefis_from_docx,
-    find_pruefidentifikatoren,
-    get_ahb_documents_path,
-    save_pruefi_map_to_toml,
-)
+from kohlrahbi.ahb import find_pruefidentifikatoren, get_ahb_documents_path, save_pruefi_map_to_toml
 from unittests import path_to_test_edi_energy_mirror_repo, path_to_test_files_fv2310
 
 

--- a/unittests/test_quality_map.py
+++ b/unittests/test_quality_map.py
@@ -1,8 +1,14 @@
+from pathlib import Path
+from typing import Union
 from unittest.mock import MagicMock
 
 import pytest
+from click.testing import CliRunner, Result
 
+from kohlrahbi import cli
 from kohlrahbi.qualitymap import is_quality_map_table
+
+runner: CliRunner = CliRunner()
 
 
 class MockCell:
@@ -23,6 +29,7 @@ class MockTable:
         raise IndexError
 
 
+@pytest.mark.snapshot
 class TestQualityMap:
 
     def test_is_quality_map_table_true(self):
@@ -37,3 +44,50 @@ class TestQualityMap:
         table = MockTable(None)
         table.cell = MagicMock(side_effect=IndexError)
         assert is_quality_map_table(table) is False
+
+    @pytest.mark.parametrize(
+        "argument_options, expected_response",
+        [
+            pytest.param(
+                [
+                    "qualitymap",
+                    "--format-version",
+                    "FV2504",
+                ],
+                {"exit_code": 0, "output_snippet": ""},
+                id="check",
+            )
+        ],
+    )
+    def test_cli_quality_map_table(
+        self, argument_options: list[str], expected_response: dict[str, Union[str, int]], snapshot, tmp_path
+    ):
+
+        actual_output_dir = tmp_path / "actual-output"
+
+        argument_options.extend(
+            [
+                "--edi-energy-mirror-path",
+                str(Path(__file__).parents[1] / "edi_energy_mirror"),
+                "--output-path",
+                str(actual_output_dir),
+                "--assume-yes",
+            ]
+        )
+
+        # Call the CLI tool with the desired arguments
+        response: Result = runner.invoke(cli, argument_options)
+
+        assert response.exit_code == expected_response.get("exit_code")
+        expected_output_snippet = expected_response.get("output_snippet")
+        if expected_output_snippet is not None and isinstance(expected_output_snippet, str):
+            assert expected_output_snippet in response.output
+        else:
+            assert False  # break the test if the output_snippet is None
+
+        # Check if the generated files are the same as the expected files
+
+        path_to_actual_csv_file = get_csv_paths(actual_output_dir)
+
+        with open(path_to_actual_csv_file[0], "r", encoding="utf-8") as actual_csv:
+            assert snapshot == actual_csv.read()

--- a/unittests/test_quality_map.py
+++ b/unittests/test_quality_map.py
@@ -32,6 +32,9 @@ class MockTable:
 
 @pytest.mark.snapshot
 class TestQualityMap:
+    """
+    This class contains the unit tests for the quality map
+    """
 
     def test_is_quality_map_table_true(self):
         table = MockTable("Qualität\n\nSegmentgruppe")
@@ -56,7 +59,7 @@ class TestQualityMap:
                     "FV2504",
                 ],
                 {"exit_code": 0, "output_snippet": ""},
-                id="check",
+                id="check command for quality map table",
             )
         ],
     )

--- a/unittests/test_quality_map.py
+++ b/unittests/test_quality_map.py
@@ -1,3 +1,4 @@
+import glob
 from pathlib import Path
 from typing import Union
 from unittest.mock import MagicMock
@@ -67,11 +68,11 @@ class TestQualityMap:
 
         argument_options.extend(
             [
+                "--assume-yes",
                 "--edi-energy-mirror-path",
                 str(Path(__file__).parents[1] / "edi_energy_mirror"),
                 "--output-path",
                 str(actual_output_dir),
-                "--assume-yes",
             ]
         )
 
@@ -79,15 +80,17 @@ class TestQualityMap:
         response: Result = runner.invoke(cli, argument_options)
 
         assert response.exit_code == expected_response.get("exit_code")
-        expected_output_snippet = expected_response.get("output_snippet")
-        if expected_output_snippet is not None and isinstance(expected_output_snippet, str):
-            assert expected_output_snippet in response.output
-        else:
-            assert False  # break the test if the output_snippet is None
 
         # Check if the generated files are the same as the expected files
 
-        path_to_actual_csv_file = get_csv_paths(actual_output_dir)
+        def get_csv_file(directory: Path) -> Path:
+            csv_files = glob.glob(str(directory / "*.csv"))
+            if csv_files:
+                return Path(csv_files[0])
+            else:
+                raise FileNotFoundError("No CSV file found in the given directory")
 
-        with open(path_to_actual_csv_file[0], "r", encoding="utf-8") as actual_csv:
+        path_to_actual_csv_file = get_csv_file(actual_output_dir)
+
+        with open(path_to_actual_csv_file, "r", encoding="utf-8") as actual_csv:
             assert snapshot == actual_csv.read()

--- a/unittests/test_quality_map.py
+++ b/unittests/test_quality_map.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from kohlrahbi.qualitymap import is_quality_map_table
+
+
+class MockCell:
+    def __init__(self, text):
+        self.text = text
+
+    def strip(self):
+        return self.text.strip()
+
+
+class MockTable:
+    def __init__(self, cell_text):
+        self.cell_text = cell_text
+
+    def cell(self, row_idx, col_idx):
+        if row_idx == 0 and col_idx == 0:
+            return MockCell(self.cell_text)
+        raise IndexError
+
+
+class TestQualityMap:
+
+    def test_is_quality_map_table_true(self):
+        table = MockTable("Qualität\n\nSegmentgruppe")
+        assert is_quality_map_table(table) is True
+
+    def test_is_quality_map_table_false(self):
+        table = MockTable("Some other text")
+        assert is_quality_map_table(table) is False
+
+    def test_is_quality_map_table_index_error(self):
+        table = MockTable(None)
+        table.cell = MagicMock(side_effect=IndexError)
+        assert is_quality_map_table(table) is False


### PR DESCRIPTION
Beispiel für den Befehl um die Quality Map auszulesen

```bash
kohlrahbi qualitymap --format-version FV2504 --output-path path/to/output/folder --edi-energy-mirror-path path/to/edi/energy/mirror/repo --assume-yes
```