### PR TITLE
ci(conventional commits): Add Labels at PRs

### DIFF
--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -12,4 +12,6 @@ jobs:
         uses:  ytanikin/PRConventionalCommits@1.3.0
         with:
           task_types: '["feat","fix","docs","style","refactor","perf","test","build","ci","chore","revert"]'
-          add_label: 'false'
+          add_label: 'true'
+          custom_labels: '{"feat": "feature", "fix": "fix", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "WIP"}'
+          # ticket_key_regex: '^PROJECT-\\d{2,5}$'


### PR DESCRIPTION
This change will later add labels to the PRs so we can quickly find what we are looking for. Here an example from the [documentation](https://github.com/ytanikin/PRConventionalCommits/tree/1.3.0/)


![](https://github.com/ytanikin/PRConventionalCommits/raw/1.3.0/pull_requests.png)

