### PR TITLE
chore: ➕Add `edi_energy_scraper` as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "tomlkit>=0.13.2",
   "xlsxwriter>=3.2.0",
   "efoli>=1.4.0",
+  "edi_energy_scraper>=2.0.0"
 ]
 
 name = "kohlrahbi"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,16 @@
 #
 #    pip-compile pyproject.toml
 #
+aiohappyeyeballs==2.4.4
+    # via aiohttp
+aiohttp==3.11.11
+    # via edi-energy-scraper
+aiosignal==1.3.2
+    # via aiohttp
 annotated-types==0.7.0
     # via pydantic
+attrs==24.3.0
+    # via aiohttp
 click==8.1.8
     # via kohlrahbi (pyproject.toml)
 colorama==0.4.6
@@ -14,30 +22,55 @@ colorama==0.4.6
     #   colorlog
 colorlog==6.9.0
     # via kohlrahbi (pyproject.toml)
-efoli==1.4.0
+edi-energy-scraper==2.0.0
     # via kohlrahbi (pyproject.toml)
+efoli==1.4.0
+    # via
+    #   edi-energy-scraper
+    #   kohlrahbi (pyproject.toml)
 et-xmlfile==2.0.0
     # via openpyxl
+frozenlist==1.5.0
+    # via
+    #   aiohttp
+    #   aiosignal
+idna==3.10
+    # via yarl
 lxml==5.3.0
     # via python-docx
 more-itertools==10.5.0
-    # via kohlrahbi (pyproject.toml)
+    # via
+    #   edi-energy-scraper
+    #   kohlrahbi (pyproject.toml)
+multidict==6.1.0
+    # via
+    #   aiohttp
+    #   yarl
 numpy==2.2.1
     # via pandas
 openpyxl==3.1.5
     # via kohlrahbi (pyproject.toml)
 pandas==2.2.3
     # via kohlrahbi (pyproject.toml)
+propcache==0.2.1
+    # via
+    #   aiohttp
+    #   yarl
 pydantic==2.9.2
-    # via kohlrahbi (pyproject.toml)
+    # via
+    #   edi-energy-scraper
+    #   kohlrahbi (pyproject.toml)
 pydantic-core==2.23.4
     # via pydantic
+pypdf==5.1.0
+    # via edi-energy-scraper
 python-dateutil==2.9.0.post0
     # via pandas
 python-docx==1.1.2
     # via kohlrahbi (pyproject.toml)
 pytz==2024.2
     # via
+    #   edi-energy-scraper
     #   efoli
     #   kohlrahbi (pyproject.toml)
     #   pandas
@@ -54,3 +87,5 @@ tzdata==2024.2
     # via pandas
 xlsxwriter==3.2.0
     # via kohlrahbi (pyproject.toml)
+yarl==1.18.3
+    # via aiohttp


### PR DESCRIPTION
next step: change the file-finding logic to the new naming schema. maybe that's a good chance to remove the by-default outdated .toml cache