### PR TITLE
docs: update README for uv-based dev setup, remove tox

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,20 +251,27 @@ The following table shows the page number of the AHBs for each format of the for
 
 ## Development
 
+This project uses [uv](https://docs.astral.sh/uv/) to manage dependencies and the development environment.
+
 ### Setup
 
-To set up the development environment, you have to install the dev dependencies.
+To set up the development environment, install [uv](https://docs.astral.sh/uv/getting-started/installation/) and sync the dev dependency group.
 
 ```bash
-tox -e dev
+uv sync --group dev
 ```
 
-### Run all tests and linters
+This creates a `.venv` and installs the package together with all development tools (tests, linting, type checking, formatting, spelling).
 
-To run the tests, you can use tox.
+### Run tests and linters
 
 ```bash
-tox
+uv run --group test pytest --cov kohlrahbi --cov-report term-missing
+uv run --group lint pylint src/kohlrahbi
+uv run --group typecheck mypy src/kohlrahbi unittests --strict
+uv run --group formatting black --check src/kohlrahbi unittests
+uv run --group formatting isort --check src/kohlrahbi unittests
+uv run --group spelling codespell src/kohlrahbi README.md
 ```
 
 See our [Python Template Repository](https://github.com/Hochfrequenz/python_template_repository#how-to-use-this-repository-on-your-machine) for detailed explanations.

--- a/README.md
+++ b/README.md
@@ -263,10 +263,10 @@ uv sync --group dev
 
 This creates a `.venv` and installs the package together with all development tools (tests, linting, type checking, formatting, spelling).
 
-### Run tests and linters
+### Run tests, linters and other checks
 
 ```bash
-uv run --group test pytest --cov kohlrahbi --cov-report term-missing
+uv run --group test pytest --cov kohlrahbi --cov-report term-missing --cov-fail-under 79
 uv run --group lint pylint src/kohlrahbi
 uv run --group typecheck mypy src/kohlrahbi unittests --strict
 uv run --group formatting black --check src/kohlrahbi unittests


### PR DESCRIPTION
## Summary
- Updates the README's Development section to reflect the project's migration from tox to uv (see #603, #605, #606)
- Replaces `tox -e dev` / `tox` instructions with `uv sync --group dev` and per-tool `uv run --group <group> ...` commands, matching what CI (`.github/workflows/checks.yaml`) actually runs

## Test plan
- [x] `grep -rniE "tox" README.md` returns no matches
- [x] Commands in the README match the groups/commands used in `.github/workflows/checks.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)