### PR TITLE
docs: remove stale tox references left over from the uv migration

### DIFF
--- a/src/kohlrahbi/models/sqlmodels/anwendungshandbuch.py
+++ b/src/kohlrahbi/models/sqlmodels/anwendungshandbuch.py
@@ -23,7 +23,7 @@ from efoli import EdifactFormat, EdifactFormatVersion
 #
 # or
 #
-# ..\.tox\dev\Lib\site-packages\sqlmodel\main.py:697: in get_sqlalchemy_type
+# site-packages/sqlmodel/main.py:697: in get_sqlalchemy_type
 #     raise ValueError(f"{type_} has no matching SQLAlchemy type")
 # E   ValueError: <class 'kohlrahbi.models.anwendungshandbuch.AhbMetaInformation'> has no matching SQLAlchemy type
 


### PR DESCRIPTION
## What

Cosmetic cleanup of a stale tox reference left over from the uv migration.

In `src/kohlrahbi/models/sqlmodels/anwendungshandbuch.py` the pasted sqlmodel
traceback in the `FlatAnwendungshandbuch` comment showed a Windows
`..\.tox\dev\Lib\site-packages\sqlmodel\main.py:697` path. The repo has been
migrated to uv and no longer has a `tox.ini`, so that path is misleading.

The comment documents a still-valid sqlmodel quirk, so the content is kept; only
the path was shortened to `site-packages/sqlmodel/main.py:697`. No behaviour
change.

## Deliberately untouched

- Historical plan/spec records under `docs/**/plans/**` and `docs/**/specs/**` (a frozen record)
- The `.tox/` line in `.gitignore` (harmless)

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)
