### PR TITLE
fix(ci): authenticate the now-private edi_energy_mirror submodule

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,8 +35,8 @@ jobs:
           # Fine-grained PAT, Contents:Read on Hochfrequenz/edi_energy_mirror only.
           # Stored in BOTH the Actions and the Dependabot secret store, because
           # Dependabot-triggered runs resolve secrets against their own store.
-          # Fine-grained PATs last at most 366 days - record the expiry date here
-          # when rotating, and rotate both copies.
+          # Expires 2027-09-07. Fine-grained PATs cannot be set to never expire, so
+          # CI breaks on that date unless both copies are rotated before it.
           MIRROR_PAT: ${{ secrets.EDI_ENERGY_MIRROR_PAT }}
           # Dependabot branches live in this repository, so they are not forks and
           # correctly take the strict branch below.

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,7 +9,11 @@ jobs:
         python-version: ["3.13"]
         check:
           - name: test
-            run: uv run --group test pytest --cov kohlrahbi --cov-report term-missing --cov-fail-under 79
+            # Without the private submodule the tests that need it skip and coverage
+            # drops to 66%, so the full gate only applies when it is present.
+            run: |
+              if [ "${{ steps.submodules.outputs.mirror }}" = "true" ]; then MIN=79; else MIN=66; fi
+              uv run --group test pytest --cov kohlrahbi --cov-report term-missing --cov-fail-under "$MIN"
           - name: lint
             run: uv run --group lint ruff check src/kohlrahbi
           - name: formatting
@@ -22,8 +26,49 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-        with:
-          submodules: true
+      # edi_energy_mirror is private, so the default GITHUB_TOKEN (scoped to this
+      # repository only) cannot clone it; `submodules:` on the checkout above would
+      # abort the whole job with "Repository not found" before any step runs.
+      - name: Check out submodules
+        id: submodules
+        env:
+          # Fine-grained PAT, Contents:Read on Hochfrequenz/edi_energy_mirror only.
+          # Stored in BOTH the Actions and the Dependabot secret store, because
+          # Dependabot-triggered runs resolve secrets against their own store.
+          MIRROR_PAT: ${{ secrets.EDI_ENERGY_MIRROR_PAT }}
+          # Dependabot branches live in this repository, so they are not forks and
+          # correctly take the strict branch below.
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          # A reused workspace can carry a stale submodule.<name>.url.
+          git submodule sync --recursive
+          if [ -z "$MIRROR_PAT" ]; then
+            if [ "$IS_FORK" = "true" ]; then
+              echo "::warning::Pull request from a fork: secrets are unavailable, so the private edi_energy_mirror submodule is skipped and the tests that need it will be skipped too."
+              echo "mirror=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::EDI_ENERGY_MIRROR_PAT is empty on a first-party run (event=$GITHUB_EVENT_NAME, actor=$GITHUB_ACTOR). Dependabot runs read the *Dependabot* secret store, not the Actions one - check that the secret exists in both."
+            exit 1
+          fi
+          # Exported rather than passed with `git -c`, so the token is not visible in
+          # the world-readable /proc/<pid>/cmdline. GIT_CONFIG_* is inherited by the
+          # submodule subprocess, and the rewrite is scoped to the Hochfrequenz org.
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0="url.https://x-access-token:$MIRROR_PAT@github.com/Hochfrequenz/.insteadOf"
+          export GIT_CONFIG_VALUE_0="https://github.com/Hochfrequenz/"
+          if ! git submodule update --init --depth=1 edi_energy_mirror; then
+            echo "::error::Could not fetch edi_energy_mirror. The most likely cause is an expired, revoked or unapproved EDI_ENERGY_MIRROR_PAT; check the repository secrets."
+            exit 1
+          fi
+          # `submodule update` also exits 0 when nothing was registered, and the
+          # directory is non-empty as soon as it holds a bare `.git` file - so probe
+          # the content the tests actually read.
+          if [ ! -d edi_energy_mirror/edi_energy_de ]; then
+            echo "::error::edi_energy_mirror/edi_energy_de is missing after 'git submodule update' - the checkout is incomplete."
+            exit 1
+          fi
+          echo "mirror=true" >> "$GITHUB_OUTPUT"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ jobs:
             # drops to 66%, so the full gate only applies when it is present.
             run: |
               if [ "${{ steps.submodules.outputs.mirror }}" = "true" ]; then MIN=79; else MIN=66; fi
-              uv run --group test pytest --cov kohlrahbi --cov-report term-missing --cov-fail-under "$MIN"
+              uv run --group test pytest -rs --cov kohlrahbi --cov-report term-missing --cov-fail-under "$MIN"
           - name: lint
             run: uv run --group lint ruff check src/kohlrahbi
           - name: formatting
@@ -35,6 +35,8 @@ jobs:
           # Fine-grained PAT, Contents:Read on Hochfrequenz/edi_energy_mirror only.
           # Stored in BOTH the Actions and the Dependabot secret store, because
           # Dependabot-triggered runs resolve secrets against their own store.
+          # Fine-grained PATs last at most 366 days - record the expiry date here
+          # when rotating, and rotate both copies.
           MIRROR_PAT: ${{ secrets.EDI_ENERGY_MIRROR_PAT }}
           # Dependabot branches live in this repository, so they are not forks and
           # correctly take the strict branch below.
@@ -53,11 +55,12 @@ jobs:
           fi
           # Exported rather than passed with `git -c`, so the token is not visible in
           # the world-readable /proc/<pid>/cmdline. GIT_CONFIG_* is inherited by the
-          # submodule subprocess, and the rewrite is scoped to the Hochfrequenz org.
+          # submodule subprocess. Scoped to this one repository, so a future
+          # Hochfrequenz submodule can never silently receive this PAT.
           export GIT_CONFIG_COUNT=1
-          export GIT_CONFIG_KEY_0="url.https://x-access-token:$MIRROR_PAT@github.com/Hochfrequenz/.insteadOf"
-          export GIT_CONFIG_VALUE_0="https://github.com/Hochfrequenz/"
-          if ! git submodule update --init --depth=1 edi_energy_mirror; then
+          export GIT_CONFIG_KEY_0="url.https://x-access-token:$MIRROR_PAT@github.com/Hochfrequenz/edi_energy_mirror.insteadOf"
+          export GIT_CONFIG_VALUE_0="https://github.com/Hochfrequenz/edi_energy_mirror"
+          if ! git submodule update --init --recursive --depth=1 edi_energy_mirror; then
             echo "::error::Could not fetch edi_energy_mirror. The most likely cause is an expired, revoked or unapproved EDI_ENERGY_MIRROR_PAT; check the repository secrets."
             exit 1
           fi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -79,8 +79,8 @@ jobs:
            # Fine-grained PAT, Contents:Read on Hochfrequenz/edi_energy_mirror only.
            # Stored in BOTH the Actions and the Dependabot secret store, because
            # Dependabot-triggered runs resolve secrets against their own store.
-           # Fine-grained PATs last at most 366 days - record the expiry date here
-           # when rotating, and rotate both copies.
+           # Expires 2027-09-07. Fine-grained PATs cannot be set to never expire, so
+           # CI breaks on that date unless both copies are rotated before it.
            MIRROR_PAT: ${{ secrets.EDI_ENERGY_MIRROR_PAT }}
            # Dependabot branches live in this repository, so they are not forks and
            # correctly take the strict branch below.

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -79,6 +79,8 @@ jobs:
            # Fine-grained PAT, Contents:Read on Hochfrequenz/edi_energy_mirror only.
            # Stored in BOTH the Actions and the Dependabot secret store, because
            # Dependabot-triggered runs resolve secrets against their own store.
+           # Fine-grained PATs last at most 366 days - record the expiry date here
+           # when rotating, and rotate both copies.
            MIRROR_PAT: ${{ secrets.EDI_ENERGY_MIRROR_PAT }}
            # Dependabot branches live in this repository, so they are not forks and
            # correctly take the strict branch below.
@@ -97,11 +99,12 @@ jobs:
            fi
            # Exported rather than passed with `git -c`, so the token is not visible in
            # the world-readable /proc/<pid>/cmdline. GIT_CONFIG_* is inherited by the
-           # submodule subprocess, and the rewrite is scoped to the Hochfrequenz org.
+           # submodule subprocess. Scoped to this one repository, so a future
+           # Hochfrequenz submodule can never silently receive this PAT.
            export GIT_CONFIG_COUNT=1
-           export GIT_CONFIG_KEY_0="url.https://x-access-token:$MIRROR_PAT@github.com/Hochfrequenz/.insteadOf"
-           export GIT_CONFIG_VALUE_0="https://github.com/Hochfrequenz/"
-           if ! git submodule update --init --depth=1 edi_energy_mirror; then
+           export GIT_CONFIG_KEY_0="url.https://x-access-token:$MIRROR_PAT@github.com/Hochfrequenz/edi_energy_mirror.insteadOf"
+           export GIT_CONFIG_VALUE_0="https://github.com/Hochfrequenz/edi_energy_mirror"
+           if ! git submodule update --init --recursive --depth=1 edi_energy_mirror; then
              echo "::error::Could not fetch edi_energy_mirror. The most likely cause is an expired, revoked or unapproved EDI_ENERGY_MIRROR_PAT; check the repository secrets."
              exit 1
            fi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -70,8 +70,49 @@ jobs:
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v7
-         with:
-           submodules: true
+       # edi_energy_mirror is private, so the default GITHUB_TOKEN (scoped to this
+       # repository only) cannot clone it; `submodules:` on the checkout above would
+       # abort the whole job with "Repository not found" before any step runs.
+       - name: Check out submodules
+         id: submodules
+         env:
+           # Fine-grained PAT, Contents:Read on Hochfrequenz/edi_energy_mirror only.
+           # Stored in BOTH the Actions and the Dependabot secret store, because
+           # Dependabot-triggered runs resolve secrets against their own store.
+           MIRROR_PAT: ${{ secrets.EDI_ENERGY_MIRROR_PAT }}
+           # Dependabot branches live in this repository, so they are not forks and
+           # correctly take the strict branch below.
+           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+         run: |
+           # A reused workspace can carry a stale submodule.<name>.url.
+           git submodule sync --recursive
+           if [ -z "$MIRROR_PAT" ]; then
+             if [ "$IS_FORK" = "true" ]; then
+               echo "::warning::Pull request from a fork: secrets are unavailable, so the private edi_energy_mirror submodule is skipped and the tests that need it will be skipped too."
+               echo "mirror=false" >> "$GITHUB_OUTPUT"
+               exit 0
+             fi
+             echo "::error::EDI_ENERGY_MIRROR_PAT is empty on a first-party run (event=$GITHUB_EVENT_NAME, actor=$GITHUB_ACTOR). Dependabot runs read the *Dependabot* secret store, not the Actions one - check that the secret exists in both."
+             exit 1
+           fi
+           # Exported rather than passed with `git -c`, so the token is not visible in
+           # the world-readable /proc/<pid>/cmdline. GIT_CONFIG_* is inherited by the
+           # submodule subprocess, and the rewrite is scoped to the Hochfrequenz org.
+           export GIT_CONFIG_COUNT=1
+           export GIT_CONFIG_KEY_0="url.https://x-access-token:$MIRROR_PAT@github.com/Hochfrequenz/.insteadOf"
+           export GIT_CONFIG_VALUE_0="https://github.com/Hochfrequenz/"
+           if ! git submodule update --init --depth=1 edi_energy_mirror; then
+             echo "::error::Could not fetch edi_energy_mirror. The most likely cause is an expired, revoked or unapproved EDI_ENERGY_MIRROR_PAT; check the repository secrets."
+             exit 1
+           fi
+           # `submodule update` also exits 0 when nothing was registered, and the
+           # directory is non-empty as soon as it holds a bare `.git` file - so probe
+           # the content the tests actually read.
+           if [ ! -d edi_energy_mirror/edi_energy_de ]; then
+             echo "::error::edi_energy_mirror/edi_energy_de is missing after 'git submodule update' - the checkout is incomplete."
+             exit 1
+           fi
+           echo "mirror=true" >> "$GITHUB_OUTPUT"
        - name: Set up Python 3.12
          uses: actions/setup-python@v7
          with:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ kohlrahbi --help
 
 > [!NOTE]
 > This command requires a local clone of the [edi_energy_mirror](https://github.com/Hochfrequenz/edi_energy_mirror/) repository, which contains the `.docx` files of the AHBs.
+> That repository is **private**, so cloning it requires a GitHub account with read access. Without it, the tests
+> that read real AHB documents are skipped and the rest of the suite still runs.
 > The folder structure should look like this:
 > ```plaintext
 > .

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -88,7 +88,7 @@ def _edi_energy_mirror_is_available() -> bool:
     return (Path(__file__).parents[1] / "edi_energy_mirror" / "edi_energy_de").is_dir()
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+def _disabled_pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """Skip the tests that need the private edi_energy_mirror submodule when it is unavailable."""
     if _edi_energy_mirror_is_available():
         return

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from pathlib import Path
 
 import docx
 import docx.table
@@ -60,3 +61,38 @@ def get_ahb_table_with_multiple_paragraphs() -> Callable[[list[CellParagraph]], 
         return result
 
     return _setup_ahb_table
+
+
+# edi_energy_mirror is a private repository, so it is not available in every CI run: pull requests
+# from forks get no secrets and therefore cannot fetch the submodule. These test modules read real
+# documents from it - unlike the rest of the suite, which uses the miniature mirror committed under
+# unittests/test-edi-energy-mirror-repo - so they are skipped instead of failing when it is absent.
+# The list is the empirically determined set: without the submodule these 8 modules produce 36
+# failures and no other module does.
+_MODULES_REQUIRING_EDI_ENERGY_MIRROR = frozenset(
+    {
+        "test_ahb.py",
+        "test_cli_changehistory_docx.py",
+        "test_cli_conditions.py",
+        "test_current_state.py",
+        "test_docxfilefinder.py",
+        "test_quality_map.py",
+        "test_read_functions.py",
+        "test_sqlmodels.py",
+    }
+)
+
+
+def _edi_energy_mirror_is_available() -> bool:
+    """Whether the edi_energy_mirror submodule is checked out and populated."""
+    return (Path(__file__).parents[1] / "edi_energy_mirror" / "edi_energy_de").is_dir()
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Skip the tests that need the private edi_energy_mirror submodule when it is unavailable."""
+    if _edi_energy_mirror_is_available():
+        return
+    skip_marker = pytest.mark.skip(reason="the private edi_energy_mirror submodule is not available")
+    for item in items:
+        if Path(str(item.fspath)).name in _MODULES_REQUIRING_EDI_ENERGY_MIRROR:
+            item.add_marker(skip_marker)


### PR DESCRIPTION
Companion to Hochfrequenz/ebd_toolchain#430. `Hochfrequenz/edi_energy_mirror` is now **private**, and the default `GITHUB_TOKEN` is scoped to the repository running the workflow, so `actions/checkout` with `submodules: true` aborts with `remote: Repository not found`.

Because that checkout is shared by **all five matrix legs** of `checks`, this breaks `lint`, `formatting`, `typecheck` and `spelling` as well as `test`, and the pre-release `test` job in `python-publish.yml` blocks releases. (Unlike ebd_toolchain, `main` here is not merge-frozen — only `validate-pr-title` is a required check.)

## What this changes

- `checks.yaml` and the `test` job of `python-publish.yml`: drop `submodules: true` and fetch the submodule in a dedicated step, using `secrets.EDI_ENERGY_MIRROR_PAT` via a `url.…insteadOf` rewrite **scoped to `Hochfrequenz/edi_energy_mirror`**. It is exported as `GIT_CONFIG_KEY_0`/`VALUE_0` rather than passed with `git -c`, so the token never lands in the world-readable `/proc/<pid>/cmdline`; the submodule subprocess inherits it either way.
- Fork PRs are detected explicitly and skip the submodule with a warning. An **empty PAT on a first-party run is a hard error** naming the Dependabot secret store — a revoked secret must not look like a fork, or CI goes green while testing nothing.
- The populated-check probes `edi_energy_de` rather than `ls -A`, which is satisfied by a directory holding only a `.git` file.
- `unittests/conftest.py`: most of the suite uses the miniature mirror committed under `unittests/test-edi-energy-mirror-repo`, but **eight** modules read the real one. Without the submodule they produce **36 failures and no other module does**, so exactly those are skipped when it is absent. Collection is unaffected — 311 tests collected either way, because the access is at runtime, not import time.
- The coverage floor follows the checkout step's own `mirror` output rather than a second path predicate that could disagree with the tests.

## Verification

| | result |
|---|---|
| without submodule | `256 passed, 55 skipped`, coverage **66%** |
| with submodule | full suite, **79%** gate unchanged |

The affected-module list was derived by running the suite with no submodule and reading the failures, not by grepping — a `parents[1]` grep misses `test_docxfilefinder.py`, which uses a CWD-relative path.

Gates before commit: pytest / ruff / `ruff format --check` / mypy `--strict` / codespell — all `0`.

## Prerequisite (already done)

`EDI_ENERGY_MIRROR_PAT` — fine-grained, resource owner `Hochfrequenz`, `Contents: Read` on `edi_energy_mirror` only — is set in **both** the Actions and the Dependabot secret stores. The credential form was validated in a real Actions run before this PR: `x-access-token:$PAT` + `insteadOf` + `--depth=1` fetched the submodule in 47s.

Independent of #430; either can merge first.